### PR TITLE
Update erigon image and params

### DIFF
--- a/fixed.vars
+++ b/fixed.vars
@@ -18,4 +18,4 @@ BESU_FIXED_VARS="--data-path=/data/besu --engine-jwt-secret=/data/jwtsecret --rp
 
 # Data dir will be mounted in /data/erigon, private api addr has been switched off because it collides
 # with lodestar prometheus endpoint. If required make adjustments accordingly
-ERIGON_FIXED_VARS="--datadir=/data/erigon --private.api.addr \"\" --http --http.api \"admin,engine,net,eth\" --http.port=8545 --http.addr 0.0.0.0 --http.corsdomain \"*\" --ws --engine.port=8551 --engine.addr=0.0.0.0 --authrpc.jwtsecret=/data/jwtsecret --allow-insecure-unlock --batchSize=32m"
+ERIGON_FIXED_VARS="--datadir=/data/erigon --private.api.addr \"\" --http --http.api \"admin,engine,net,eth,web3\" --http.port=8545 --http.addr 0.0.0.0 --http.corsdomain \"*\" --ws --engine.port=8551 --engine.addr=0.0.0.0 --authrpc.jwtsecret=/data/jwtsecret --allow-insecure-unlock --prune=htc --prune.r.before=1 --batchSize=32m"

--- a/goerli.vars
+++ b/goerli.vars
@@ -20,7 +20,7 @@ GETH_IMAGE=ethereum/client-go:latest
 NETHERMIND_IMAGE=nethermind/nethermind:latest
 ETHEREUMJS_IMAGE=g11tech/ethereumjs:kiln
 BESU_IMAGE=hyperledger/besu:develop
-ERIGON_IMAGE=parithoshj/erigon:devel-fb9f193
+ERIGON_IMAGE=thorax/erigon:v2022.07.04
 
 LODESTAR_IMAGE=chainsafe/lodestar:next
 


### PR DESCRIPTION
This updates the Erigon image to the latest used in Goerli shadow fork 6 and params updated to get rid of the 

`error: Error updating eth1 chain cache  Error setting depositRootTree index` error.