### PR TITLE
Enable logging by default

### DIFF
--- a/fixed.vars
+++ b/fixed.vars
@@ -1,5 +1,5 @@
 # Data dir will be mounted in /data/lodestar
-LODESTAR_FIXED_VARS="--dataDir /data/lodestar --execution.urls http://127.0.0.1:8551 --rest.address 0.0.0.0 --rest.namespace '*' --jwt-secret /data/jwtsecret"
+LODESTAR_FIXED_VARS="--dataDir /data/lodestar --execution.urls http://127.0.0.1:8551 --rest.address 0.0.0.0 --rest.namespace '*' --jwt-secret /data/jwtsecret --logFile /logs/beacon.log --logFileLevel debug --logFileDailyRotate 5"
 
 # Data dir will be mounted in /data/lodestar
 LODESTAR_VAL_FIXED_VARS="--dataDir /data/lodestar"


### PR DESCRIPTION
As mentioned in https://github.com/ChainSafe/lodestar/issues/4527, it would be wise for us to enable logging by default for our quickstart scripts as well.