### PR TITLE
Remove mainnet merge ttd override

### DIFF
--- a/fixed.vars
+++ b/fixed.vars
@@ -1,5 +1,5 @@
 # Data dir will be mounted in /data/lodestar
-LODESTAR_FIXED_VARS="--dataDir /data/lodestar --execution.urls http://127.0.0.1:8551 --rest.address 0.0.0.0 --rest.namespace '*' --jwt-secret /data/jwtsecret --logFile /logs/beacon.log --logFileLevel debug --logFileDailyRotate 5"
+LODESTAR_FIXED_VARS="--dataDir /data/lodestar --execution.urls http://127.0.0.1:8551 --rest.address 0.0.0.0 --rest.namespace '*' --jwt-secret /data/jwtsecret --logFile /data/lodestar/beacon.log --logFileLevel debug --logFileDailyRotate 5"
 
 # Data dir will be mounted in /data/lodestar
 LODESTAR_VAL_FIXED_VARS="--dataDir /data/lodestar"

--- a/mainnet.vars
+++ b/mainnet.vars
@@ -24,18 +24,18 @@ ERIGON_IMAGE=thorax/erigon:v2022.08.03
 
 LODESTAR_IMAGE=chainsafe/lodestar:latest
 
-LODESTAR_EXTRA_ARGS="--network mainnet --terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
+LODESTAR_EXTRA_ARGS="--network mainnet $LODESTAR_FIXED_VARS"
 
 LODESTAR_VALIDATOR_ARGS="--network mainnet $LODESTAR_VAL_FIXED_VARS --suggestedFeeRecipient $FEE_RECIPIENT"
 
-NETHERMIND_EXTRA_ARGS="--config mainnet  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
+NETHERMIND_EXTRA_ARGS="--config mainnet $NETHERMIND_FIXED_VARS"
 
-GETH_EXTRA_ARGS="--mainnet --override.terminaltotaldifficulty=$MERGE_TTD --networkid $NETWORK_ID $GETH_FIXED_VARS"
+GETH_EXTRA_ARGS="--mainnet --networkid $NETWORK_ID $GETH_FIXED_VARS"
 
 ETHEREUMJS_EXTRA_ARGS="$ETHEREUMJS_FIXED_VARS"
 
 BESU_EXTRA_ARGS="--network-id=$NETWORK_ID $BESU_FIXED_VARS"
 
-ERIGON_EXTRA_ARGS="erigon --chain=mainnet --networkid=$NETWORK_ID --override.terminaltotaldifficulty=$MERGE_TTD $ERIGON_FIXED_VARS"
+ERIGON_EXTRA_ARGS="erigon --chain=mainnet --networkid=$NETWORK_ID $ERIGON_FIXED_VARS"
 
 EXTRA_BOOTNODES=""


### PR DESCRIPTION
Cleanup `mainnet.vars` from  merge ttd overrides post successful merge, as well as fix the logging director of the lodestar beacon to the mounted one for the data.