### PR TITLE
Image and config updates for besu and erigon

### DIFF
--- a/fixed.vars
+++ b/fixed.vars
@@ -18,7 +18,7 @@ BESU_FIXED_VARS="--data-path=/data/besu --engine-jwt-secret=/data/jwtsecret --rp
 
 # Data dir will be mounted in /data/erigon, private api addr has been switched off because it collides
 # with lodestar prometheus endpoint. If required make adjustments accordingly
-ERIGON_FIXED_VARS="--datadir=/data/erigon --private.api.addr \"\" --http --authrpc.port=8551 --authrpc.addr=0.0.0.0 --authrpc.jwtsecret=/data/jwtsecret --batchSize=32m"
+ERIGON_FIXED_VARS="--datadir=/data/erigon --private.api.addr \"\" --http --authrpc.port=8551 --authrpc.addr=0.0.0.0 --authrpc.jwtsecret=/data/jwtsecret --batchSize=32m --externalcl"
 
 # Data dir will be mounted to /data/mevboost
 MEVBOOST_FIXED_VARS="-relay-check -debug -addr 0.0.0.0:18550"

--- a/goerli.vars
+++ b/goerli.vars
@@ -22,8 +22,8 @@ MERGE_TTD=10790000
 GETH_IMAGE=ethereum/client-go:latest
 NETHERMIND_IMAGE=nethermind/nethermind:latest
 ETHEREUMJS_IMAGE=g11tech/ethereumjs:kiln
-BESU_IMAGE=hyperledger/besu:develop
-ERIGON_IMAGE=thorax/erigon:v2022.08.03
+BESU_IMAGE=hyperledger/besu:latest
+ERIGON_IMAGE=thorax/erigon:stable
 MEV_BOOST_IMAGE=flashbots/mev-boost:latest
 
 RELAY_A=https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@builder-relay-goerli.flashbots.net

--- a/mainnet.vars
+++ b/mainnet.vars
@@ -22,8 +22,8 @@ MERGE_TTD=58750000000000000000000
 GETH_IMAGE=ethereum/client-go:latest
 NETHERMIND_IMAGE=nethermind/nethermind:latest
 ETHEREUMJS_IMAGE=g11tech/ethereumjs:kiln
-BESU_IMAGE=hyperledger/besu:develop
-ERIGON_IMAGE=thorax/erigon:v2022.08.03
+BESU_IMAGE=hyperledger/besu:latest
+ERIGON_IMAGE=thorax/erigon:stable
 MEV_BOOST_IMAGE=flashbots/mev-boost:latest
 
 RELAY_A=https://0xa15b52576bcbf1072f4a011c0f99f9fb6c66f3e1ff321f11f461d15e31b1cb359caa092c71bbded0bae5b5ea401aab7e@aestus.live

--- a/sepolia.vars
+++ b/sepolia.vars
@@ -22,8 +22,8 @@ MERGE_TTD=17000000000000000
 GETH_IMAGE=ethereum/client-go:latest
 NETHERMIND_IMAGE=nethermind/nethermind:latest
 ETHEREUMJS_IMAGE=g11tech/ethereumjs:kiln
-BESU_IMAGE=hyperledger/besu:develop
-ERIGON_IMAGE=thorax/erigon:v2022.08.03
+BESU_IMAGE=hyperledger/besu:latest
+ERIGON_IMAGE=thorax/erigon:stable
 MEV_BOOST_IMAGE=flashbots/mev-boost:latest
 
 RELAYS="https://0x845bd072b7cd566f02faeb0a4033ce9399e42839ced64e8b2adcfc859ed1e8e1a5a293336a49feac6d9a5edb779be53a@boost-relay-sepolia.flashbots.net"


### PR DESCRIPTION
This PR updates besu image to `besu:latest` and erigon image to `erigon:stable`. External CL config arg now required when not using their internal consensus light client. Added `--externalcl` for this.