### PR TITLE
Add kaustinen 2 network launching capability

### DIFF
--- a/kaustinen.vars
+++ b/kaustinen.vars
@@ -1,0 +1,45 @@
+LODESTAR_VALIDATOR_KEYSTORE_ARGS="--importKeystores /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
+
+LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
+
+# This will be available in /data/jwtsecret
+JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
+
+FEE_RECIPIENT="0xcccccccccccccccccccccccccccccccccccccccc"
+
+# Specify this as "-min-bid <value>"
+MIN_BUILDERBID=0
+
+#---------------- Only Modify below if you know what you are doing ----------------
+#----------------------------------------------------------------------------------
+
+DEVNET_NAME=kaustinen
+SETUP_CONFIG_URL=https://github.com/ethpandaops/verkle-testnets
+CONFIG_GIT_DIR=network-configs/kaustinen-testnet
+SETUP_CONFIG_BRANCH=master
+
+NETWORK_ID=69420
+
+GETH_IMAGE=ethpandaops/geth:gballet-kaustinen-with-shapella
+NETHERMIND_IMAGE=nethermind/nethermind:latest
+ETHEREUMJS_IMAGE=g11tech/ethereumjs:kiln
+BESU_IMAGE=hyperledger/besu:develop
+
+LODESTAR_IMAGE=ethpandaops/lodestar:g11tech-verge
+
+LODESTAR_EXTRA_ARGS="$LODESTAR_FIXED_VARS"
+
+LODESTAR_VALIDATOR_ARGS="$LODESTAR_VAL_FIXED_VARS --suggestedFeeRecipient $FEE_RECIPIENT"
+
+NETHERMIND_EXTRA_ARGS="$NETHERMIND_FIXED_VARS"
+
+GETH_EXTRA_ARGS="--networkid $NETWORK_ID $GETH_FIXED_VARS --cache.preimages"
+GETH_EXTRA_INIT_PARAMS="--cache.preimages"
+
+ETHEREUMJS_EXTRA_ARGS="$ETHEREUMJS_FIXED_VARS --gethGenesis /config/genesis.json"
+
+BESU_EXTRA_ARGS="--network-id=$NETWORK_ID $BESU_FIXED_VARS"
+
+EXTRA_BOOTNODES=""
+
+# ./lodestar beacon --dataDir lodestar-quickstart/kaustinen-data/lodestar --paramsFile lodestar-quickstart/kaustinen-data/kaustinen-testnet/custom_config_data/config.yaml --genesisStateFile lodestar-quickstart/kaustinen-data/kaustinen-testnet/custom_config_data/genesis.ssz --bootnodesFile lodestar-quickstart/kaustinen-data/kaustinen-testnet/custom_config_data/boot_enr.yaml

--- a/kaustinen.vars
+++ b/kaustinen.vars
@@ -33,7 +33,7 @@ LODESTAR_VALIDATOR_ARGS="$LODESTAR_VAL_FIXED_VARS --suggestedFeeRecipient $FEE_R
 
 NETHERMIND_EXTRA_ARGS="$NETHERMIND_FIXED_VARS"
 
-GETH_EXTRA_ARGS="--networkid $NETWORK_ID $GETH_FIXED_VARS --cache.preimages"
+GETH_EXTRA_ARGS="--networkid $NETWORK_ID $GETH_FIXED_VARS --cache.preimages --syncmode full"
 GETH_EXTRA_INIT_PARAMS="--cache.preimages"
 
 ETHEREUMJS_EXTRA_ARGS="$ETHEREUMJS_FIXED_VARS --gethGenesis /config/genesis.json"


### PR DESCRIPTION
adds kaustinen 2 network

Current `geth` supported, support with `nethermind` incoming

### How to run both EL & CL
`./setup.sh --dataDir k2data --network kaustinen --elClient geth`

### How to just run lodestar (for EL client devs)
Just add `--justCL` to the above command (and you may omit --elClient as well)
`./setup.sh --dataDir k2data --network kaustinen --justCL`

### How to just run geth (for CL client devs)

Just add `--justEL` to the above command:
`./setup.sh --dataDir k2data --network kaustinen --elClient geth --justEL`

## Where are the config files:
 in the `$dataDir/network-configs/kaustinen-testnet`
the `jwtsecret` file is written in `$dataDir/jwtsecret` so you might have to run any of the above commands first so you can use it to run your client