### PR TITLE
enable nethermind for kaustinen verkle

### DIFF
--- a/kaustinen.vars
+++ b/kaustinen.vars
@@ -1,4 +1,4 @@
-LODESTAR_VALIDATOR_KEYSTORE_ARGS="--importKeystores /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
+LODESTAR_VALIDATOR_KEYSTORE_ARGS="--importKeystores /keystoresDir/keystores --importKeystoresPassword /keystoresDir/pass.txt"
 
 LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
 
@@ -15,9 +15,7 @@ NETWORK_ID=69420
 
 GETH_IMAGE=ethpandaops/geth:kaustinen-with-shapella
 GETH_INIT_IMAGE=ethpandaops/geth:force-verkle-genesis-f595f90
-NETHERMIND_IMAGE=nethermind/nethermind:latest
-ETHEREUMJS_IMAGE=g11tech/ethereumjs:kiln
-BESU_IMAGE=hyperledger/besu:develop
+NETHERMIND_IMAGE=nethermindeth/nethermind:kaustinen
 
 LODESTAR_IMAGE=ethpandaops/lodestar:g11tech-verge
 
@@ -25,7 +23,9 @@ LODESTAR_EXTRA_ARGS="$LODESTAR_FIXED_VARS --checkpointSyncUrl https://eth:g11tec
 
 LODESTAR_VALIDATOR_ARGS="$LODESTAR_VAL_FIXED_VARS --suggestedFeeRecipient $FEE_RECIPIENT"
 
-NETHERMIND_EXTRA_ARGS="$NETHERMIND_FIXED_VARS"
+NETHERMIND_EXTRA_ARGS="--config kaustinen --Merge.TerminalTotalDifficulty=0 $NETHERMIND_FIXED_VARS"
+# nethermind image has inbuild config
+NETHERMIND_INBUILD_CONFIG=true
 
 GETH_EXTRA_ARGS="--networkid $NETWORK_ID $GETH_FIXED_VARS --cache.preimages --syncmode full --override.prague=1697196984"
 GETH_EXTRA_INIT_PARAMS="--cache.preimages"

--- a/setup.sh
+++ b/setup.sh
@@ -220,7 +220,7 @@ elif [ "$elClient" == "nethermind" ]
 then
   echo "nethermindImage: $NETHERMIND_IMAGE"
 
-  if [ -n "$configGitDir" ] && [ ! -n "$(ls -A $dataDir/$configGitDir/nethermind_genesis.json)" ]
+  if [ -n "$configGitDir" ] && [ ! -n "$(ls -A $dataDir/$configGitDir/chainspec.json)" ]
   then
     echo "nethermind genesis file not found in config, exiting... "
     exit;
@@ -230,7 +230,11 @@ then
   elCmd="$dockerCmd --name $elName $elDockerNetwork -v $currentDir/$dataDir:/data"
   if [ -n "$configGitDir" ]
   then
-    elCmd="$elCmd -v $currentDir/$dataDir/$configGitDir:/config  $NETHERMIND_IMAGE --Init.ChainSpecPath=/config/nethermind_genesis.json --Discovery.Bootnodes $EXTRA_BOOTNODES$bootNode"
+    elCmd="$elCmd -v $currentDir/$dataDir/$configGitDir:/config $NETHERMIND_IMAGE --Discovery.Bootnodes $EXTRA_BOOTNODES$bootNode"
+    if [ ! -n "$NETHERMIND_INBUILD_CONFIG" ]
+    then
+      elCmd="$elCmd --Init.ChainSpecPath=/config/chainspec.json"
+    fi;
   else
     elCmd="$elCmd $NETHERMIND_IMAGE"
   fi;


### PR DESCRIPTION
now nethermind can be used to sync kaustinen network via:

`./setup.sh --dataDir k2data --network kaustinen --elClient nethermind`

(if the checkpoint sync is failing then in kaustinen.vars remove checkpoint sync arg and url from LODESTAR_EXTRA_ARGS) and let the client sync forward from genesis