### PR TITLE
Update checkpoint URLs

### DIFF
--- a/holesky.vars
+++ b/holesky.vars
@@ -14,7 +14,7 @@ RELAYS=""
 
 LODESTAR_IMAGE=chainsafe/lodestar:latest
 
-LODESTAR_EXTRA_ARGS="--network holesky $LODESTAR_FIXED_VARS --checkpointSyncUrl https://lodestar-holesky.chainsafe.io"
+LODESTAR_EXTRA_ARGS="--network holesky $LODESTAR_FIXED_VARS --checkpointSyncUrl https://beaconstate-holesky.chainsafe.io"
 
 LODESTAR_VALIDATOR_ARGS="--network holesky $LODESTAR_VAL_FIXED_VARS --suggestedFeeRecipient $FEE_RECIPIENT"
 

--- a/mainnet.vars
+++ b/mainnet.vars
@@ -22,7 +22,7 @@ RELAY_H=https://0xa1559ace749633b997cb3fdacffb890aeebdb0f5a3b6aaa7eeeaf1a38af0a8
 
 RELAYS="$RELAY_A,$RELAY_B,$RELAY_C,$RELAY_D,$RELAY_E,$RELAY_F,$RELAY_G,$RELAY_H"
 
-LODESTAR_EXTRA_ARGS="--network mainnet $LODESTAR_FIXED_VARS --suggestedFeeRecipient $FEE_RECIPIENT --checkpointSyncUrl https://lodestar-mainnet.chainsafe.io"
+LODESTAR_EXTRA_ARGS="--network mainnet $LODESTAR_FIXED_VARS --suggestedFeeRecipient $FEE_RECIPIENT --checkpointSyncUrl https://beaconstate-mainnet.chainsafe.io"
 
 LODESTAR_VALIDATOR_ARGS="--network mainnet $LODESTAR_VAL_FIXED_VARS --suggestedFeeRecipient $FEE_RECIPIENT"
 

--- a/sepolia.vars
+++ b/sepolia.vars
@@ -14,7 +14,7 @@ MERGE_TTD=17000000000000000
 RELAYS="https://0x845bd072b7cd566f02faeb0a4033ce9399e42839ced64e8b2adcfc859ed1e8e1a5a293336a49feac6d9a5edb779be53a@boost-relay-sepolia.flashbots.net"
 
 
-LODESTAR_EXTRA_ARGS="--network sepolia $LODESTAR_FIXED_VARS --checkpointSyncUrl https://lodestar-sepolia.chainsafe.io"
+LODESTAR_EXTRA_ARGS="--network sepolia $LODESTAR_FIXED_VARS --checkpointSyncUrl https://beaconstate-sepolia.chainsafe.io"
 
 LODESTAR_VALIDATOR_ARGS="--network sepolia $LODESTAR_VAL_FIXED_VARS --suggestedFeeRecipient $FEE_RECIPIENT"
 


### PR DESCRIPTION
Update to use the direct URL to the host of the beacon state. Sometimes downloading doesn't resolve when using the public URL. 