### PR TITLE
configure kautinen for its 4rth iteration

### DIFF
--- a/kaustinen4.vars
+++ b/kaustinen4.vars
@@ -5,16 +5,16 @@ LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb pla
 #---------------- Only Modify below if you know what you are doing ----------------
 #----------------------------------------------------------------------------------
 
-# https://verkle-gen-devnet-2.ethpandaops.io/
+# https://verkle-gen-devnet-4.ethpandaops.io/
 DEVNET_NAME=kaustinen
 SETUP_CONFIG_URL=https://github.com/ethpandaops/verkle-testnets
-CONFIG_GIT_DIR=network-configs/gen-devnet-3
+CONFIG_GIT_DIR=network-configs/gen-devnet-4
 SETUP_CONFIG_BRANCH=master
-SETUP_CONFIG_INVENTORY_URL=https://config.verkle-gen-devnet-3.ethpandaops.io/api/v1/nodes/inventory
+SETUP_CONFIG_INVENTORY_URL=https://config.verkle-gen-devnet-4.ethpandaops.io/api/v1/nodes/inventory
 
-NETWORK_ID=69421
+NETWORK_ID=69420
 
-GETH_IMAGE=ethpandaops/geth:kaustinen-with-shapella-28ec376
+GETH_IMAGE=ethpandaops/geth:kaustinen-with-shapella-0b110bd
 NETHERMIND_IMAGE=nethermindeth/nethermind:kaustinen
 
 LODESTAR_IMAGE=ethpandaops/lodestar:g11tech-verge
@@ -22,8 +22,8 @@ LODESTAR_IMAGE=ethpandaops/lodestar:g11tech-verge
 # Uncomment the following the comment the one below if you want to sync from genesis probably because your EL
 # doesn't support backfill sync ( for e.g. ethereumjs stateless sync etc)
 #
-#LODESTAR_EXTRA_ARGS="$LODESTAR_FIXED_VARS"
-LODESTAR_EXTRA_ARGS="$LODESTAR_FIXED_VARS --checkpointSyncUrl https://checkpoint-sync.verkle-gen-devnet-3.ethpandaops.io"
+LODESTAR_EXTRA_ARGS="$LODESTAR_FIXED_VARS"
+#LODESTAR_EXTRA_ARGS="$LODESTAR_FIXED_VARS --checkpointSyncUrl https://checkpoint-sync.verkle-gen-devnet-4.ethpandaops.io"
 
 LODESTAR_VALIDATOR_ARGS="$LODESTAR_VAL_FIXED_VARS --suggestedFeeRecipient $FEE_RECIPIENT"
 
@@ -31,8 +31,8 @@ NETHERMIND_EXTRA_ARGS="--config kaustinen --Merge.TerminalTotalDifficulty=0 $NET
 # nethermind image has inbuild config
 NETHERMIND_INBUILD_CONFIG=true
 
-GETH_EXTRA_ARGS="--networkid $NETWORK_ID $GETH_FIXED_VARS --cache.preimages --syncmode full --override.prague=1706865900"
-GETH_EXTRA_INIT_PARAMS="--cache.preimages --override.prague=1700825700"
+GETH_EXTRA_ARGS="--networkid $NETWORK_ID $GETH_FIXED_VARS --cache.preimages --syncmode full --override.prague=1707215340"
+GETH_EXTRA_INIT_PARAMS="--cache.preimages --override.prague=1707215340"
 
 ETHEREUMJS_EXTRA_ARGS="$ETHEREUMJS_FIXED_VARS --gethGenesis /config/genesis.json"
 


### PR DESCRIPTION
kautinene4 is launched with some fixes over  kautinen3

how to run:

```
./setup.sh --dataDir k4data --network kaustinen4 --elClient geth
```

this syncs from genesis, to enable checkpoint sync edit `kautinen4.vars` and comment line 25, and uncomment line 26