### PR TITLE
configure kaustinen5 network for verkle

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Look for the .vars file in the folder to see what networks are supported. There 
 
 1. Sepolia Network: `--network sepolia` (reads `sepolia.vars`)
 2. Holesky Network: `--network holesky` (reads `holesky.vars`)
-3. Verkle Kautinen 3: `--network kaustinen3` (reads `kaustinen3.vars`)
+3. Verkle Kautinen 5: `--network kaustinen5` (reads `kaustinen5.vars`)
 4. **Mainnet**: `--network mainnet` (reads `mainnet.vars`)
 
 Goerli network has been removed as it has been deprecated/sunsetted.

--- a/kaustinen5.vars
+++ b/kaustinen5.vars
@@ -5,16 +5,16 @@ LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb pla
 #---------------- Only Modify below if you know what you are doing ----------------
 #----------------------------------------------------------------------------------
 
-# https://verkle-gen-devnet-4.ethpandaops.io/
+# https://verkle-gen-devnet-5.ethpandaops.io/
 DEVNET_NAME=kaustinen
-SETUP_CONFIG_URL=https://github.com/ethpandaops/verkle-testnets
-CONFIG_GIT_DIR=network-configs/gen-devnet-4
+SETUP_CONFIG_URL=https://github.com/ethpandaops/verkle-devnets
+CONFIG_GIT_DIR=network-configs/gen-devnet-5
 SETUP_CONFIG_BRANCH=master
-SETUP_CONFIG_INVENTORY_URL=https://config.verkle-gen-devnet-4.ethpandaops.io/api/v1/nodes/inventory
+SETUP_CONFIG_INVENTORY_URL=https://config.verkle-gen-devnet-5.ethpandaops.io/api/v1/nodes/inventory
 
 NETWORK_ID=69420
 
-GETH_IMAGE=ethpandaops/geth:kaustinen-with-shapella-0b110bd
+GETH_IMAGE=ethpandaops/geth:gballet-eip-4762-rewrite-44c1724
 NETHERMIND_IMAGE=nethermindeth/nethermind:kaustinen
 
 LODESTAR_IMAGE=ethpandaops/lodestar:g11tech-verge
@@ -22,8 +22,8 @@ LODESTAR_IMAGE=ethpandaops/lodestar:g11tech-verge
 # Uncomment the following the comment the one below if you want to sync from genesis probably because your EL
 # doesn't support backfill sync ( for e.g. ethereumjs stateless sync etc)
 #
-#LODESTAR_EXTRA_ARGS="$LODESTAR_FIXED_VARS"
-LODESTAR_EXTRA_ARGS="$LODESTAR_FIXED_VARS --checkpointSyncUrl https://eth:g11techisntoneperson@bn.lodestar-geth-9.verkle-gen-devnet-4.ethpandaops.io"
+LODESTAR_EXTRA_ARGS="$LODESTAR_FIXED_VARS"
+# LODESTAR_EXTRA_ARGS="$LODESTAR_FIXED_VARS --checkpointSyncUrl https://eth:g11techisntoneperson@bn.lodestar-geth-9.verkle-gen-devnet-5.ethpandaops.io"
 
 LODESTAR_VALIDATOR_ARGS="$LODESTAR_VAL_FIXED_VARS --suggestedFeeRecipient $FEE_RECIPIENT"
 
@@ -31,8 +31,8 @@ NETHERMIND_EXTRA_ARGS="--config kaustinen --Merge.TerminalTotalDifficulty=0 $NET
 # nethermind image has inbuild config
 NETHERMIND_INBUILD_CONFIG=true
 
-GETH_EXTRA_ARGS="--networkid $NETWORK_ID $GETH_FIXED_VARS --cache.preimages --syncmode full --override.prague=1707215340"
-GETH_EXTRA_INIT_PARAMS="--cache.preimages --override.prague=1707215340"
+GETH_EXTRA_ARGS="--networkid $NETWORK_ID $GETH_FIXED_VARS --cache.preimages --syncmode full --override.prague=1711712640"
+GETH_EXTRA_INIT_PARAMS="--cache.preimages --override.prague=1711712640"
 
 ETHEREUMJS_EXTRA_ARGS="$ETHEREUMJS_FIXED_VARS --gethGenesis /config/genesis.json"
 


### PR DESCRIPTION
kaustinen5 has been launched to replace kautstinen4 and hence this PR

`./setup.sh --network kaustinen5 --dataDir k5data --elClient geth`