### PR TITLE
update kaustinen6 to its second relaunch iteration

### DIFF
--- a/kaustinen6.vars
+++ b/kaustinen6.vars
@@ -14,7 +14,7 @@ SETUP_CONFIG_INVENTORY_URL=https://config.verkle-gen-devnet-6.ethpandaops.io/api
 
 NETWORK_ID=69420
 
-GETH_IMAGE=ethpandaops/geth:gballet-eip-4762-rewrite-ea20444
+GETH_IMAGE=ethpandaops/geth:gballet-eip-4762-rewrite-2933731
 NETHERMIND_IMAGE=nethermindeth/nethermind:kaustinen
 
 LODESTAR_IMAGE=ethpandaops/lodestar:g11tech-verge
@@ -31,8 +31,8 @@ NETHERMIND_EXTRA_ARGS="--config kaustinen --Merge.TerminalTotalDifficulty=0 $NET
 # nethermind image has inbuild config
 NETHERMIND_INBUILD_CONFIG=true
 
-GETH_EXTRA_ARGS="--networkid $NETWORK_ID $GETH_FIXED_VARS --cache.preimages --syncmode full --override.prague=1712848500"
-GETH_EXTRA_INIT_PARAMS="--cache.preimages --override.prague=1712848500"
+GETH_EXTRA_ARGS="--networkid $NETWORK_ID $GETH_FIXED_VARS --cache.preimages --syncmode full --override.prague=1712918400"
+GETH_EXTRA_INIT_PARAMS="--cache.preimages --override.prague=1712918400"
 
 ETHEREUMJS_EXTRA_ARGS="$ETHEREUMJS_FIXED_VARS --gethGenesis /config/genesis.json"
 


### PR DESCRIPTION
first iteration was rebooted because of some issues with the geth image which are not fixed in the relaunch, this PR updates the image and config params for second iteration

run as:
`./setup.sh --network kaustinen6 --elClient geth --dataDir k6data`