### PR TITLE
Update relays May 2024

### DIFF
--- a/holesky.vars
+++ b/holesky.vars
@@ -10,7 +10,14 @@ DEVNET_NAME=holesky
 CONFIG_GIT_DIR=
 NETWORK_ID=17000
 
-RELAYS=""
+RELAYS_A=https://0xab78bf8c781c58078c3beb5710c57940874dd96aef2835e7742c866b4c7c0406754376c2c8285a36c630346aa5c5f833@holesky.aestus.live
+RELAYS_B=https://0x821f2a65afb70e7f2e820a925a9b4c80a159620582c1766b1b09729fec178b11ea22abb3a51f07b288be815a1a2ff516@bloxroute.holesky.blxrbdn.com
+RELAYS_C=https://0xb1d229d9c21298a87846c7022ebeef277dfc321fe674fa45312e20b5b6c400bfde9383f801848d7837ed5fc449083a12@relay-holesky.edennetwork.io
+RELAYS_D=https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@boost-relay-holesky.flashbots.net
+RELAYS_E=https://0xaa58208899c6105603b74396734a6263cc7d947f444f396a90f7b7d3e65d102aec7e5e5291b27e08d02c50a050825c2f@holesky.titanrelay.xyz
+RELAYS_F=https://0xb1559beef7b5ba3127485bbbb090362d9f497ba64e177ee2c8e7db74746306efad687f2cf8574e38d70067d40ef136dc@relay-stag.ultrasound.money
+
+RELAYS="$RELAY_A,$RELAY_B,$RELAY_C,$RELAY_D,$RELAY_E,$RELAY_F"
 
 LODESTAR_IMAGE=chainsafe/lodestar:latest
 

--- a/holesky.vars
+++ b/holesky.vars
@@ -10,12 +10,12 @@ DEVNET_NAME=holesky
 CONFIG_GIT_DIR=
 NETWORK_ID=17000
 
-RELAYS_A=https://0xab78bf8c781c58078c3beb5710c57940874dd96aef2835e7742c866b4c7c0406754376c2c8285a36c630346aa5c5f833@holesky.aestus.live
-RELAYS_B=https://0x821f2a65afb70e7f2e820a925a9b4c80a159620582c1766b1b09729fec178b11ea22abb3a51f07b288be815a1a2ff516@bloxroute.holesky.blxrbdn.com
-RELAYS_C=https://0xb1d229d9c21298a87846c7022ebeef277dfc321fe674fa45312e20b5b6c400bfde9383f801848d7837ed5fc449083a12@relay-holesky.edennetwork.io
-RELAYS_D=https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@boost-relay-holesky.flashbots.net
-RELAYS_E=https://0xaa58208899c6105603b74396734a6263cc7d947f444f396a90f7b7d3e65d102aec7e5e5291b27e08d02c50a050825c2f@holesky.titanrelay.xyz
-RELAYS_F=https://0xb1559beef7b5ba3127485bbbb090362d9f497ba64e177ee2c8e7db74746306efad687f2cf8574e38d70067d40ef136dc@relay-stag.ultrasound.money
+RELAY_A=https://0xab78bf8c781c58078c3beb5710c57940874dd96aef2835e7742c866b4c7c0406754376c2c8285a36c630346aa5c5f833@holesky.aestus.live
+RELAY_B=https://0x821f2a65afb70e7f2e820a925a9b4c80a159620582c1766b1b09729fec178b11ea22abb3a51f07b288be815a1a2ff516@bloxroute.holesky.blxrbdn.com
+RELAY_C=https://0xb1d229d9c21298a87846c7022ebeef277dfc321fe674fa45312e20b5b6c400bfde9383f801848d7837ed5fc449083a12@relay-holesky.edennetwork.io
+RELAY_D=https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@boost-relay-holesky.flashbots.net
+RELAY_E=https://0xaa58208899c6105603b74396734a6263cc7d947f444f396a90f7b7d3e65d102aec7e5e5291b27e08d02c50a050825c2f@holesky.titanrelay.xyz
+RELAY_F=https://0xb1559beef7b5ba3127485bbbb090362d9f497ba64e177ee2c8e7db74746306efad687f2cf8574e38d70067d40ef136dc@relay-stag.ultrasound.money
 
 RELAYS="$RELAY_A,$RELAY_B,$RELAY_C,$RELAY_D,$RELAY_E,$RELAY_F"
 
@@ -39,4 +39,4 @@ ERIGON_EXTRA_ARGS="erigon --chain=holesky --networkid=$NETWORK_ID $ERIGON_FIXED_
 
 EXTRA_BOOTNODES=""
 
-MEVBOOST_VARS=""
+MEVBOOST_VARS="-holesky -relays $RELAYS -min-bid $MIN_BUILDERBID $MEVBOOST_FIXED_VARS"

--- a/mainnet.vars
+++ b/mainnet.vars
@@ -19,8 +19,10 @@ RELAY_E=https://0xb3ee7afcf27f1f1259ac1787876318c6584ee353097a50ed84f51a1f21a323
 RELAY_F=https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net
 RELAY_G=https://0x98650451ba02064f7b000f5768cf0cf4d4e492317d82871bdc87ef841a0743f69f0f1eea11168503240ac35d101c9135@mainnet-relay.securerpc.com
 RELAY_H=https://0xa1559ace749633b997cb3fdacffb890aeebdb0f5a3b6aaa7eeeaf1a38af0a8fe88b9e4b1f61f236d2e64d95733327a62@relay.ultrasound.money
+RELAY_I=https://0x8c4ed5e24fe5c6ae21018437bde147693f68cda427cd1122cf20819c30eda7ed74f72dece09bb313f2a1855595ab677d@titanrelay.xyz
+RELAY_J=https://0x8c7d33605ecef85403f8b7289c8058f440cbb6bf72b055dfe2f3e2c6695b6a1ea5a9cd0eb3a7982927a463feb4c3dae2@relay.wenmerge.com
 
-RELAYS="$RELAY_A,$RELAY_B,$RELAY_C,$RELAY_D,$RELAY_E,$RELAY_F,$RELAY_G,$RELAY_H"
+RELAYS="$RELAY_A,$RELAY_B,$RELAY_C,$RELAY_D,$RELAY_E,$RELAY_F,$RELAY_G,$RELAY_H,$RELAY_I,$RELAY_J"
 
 LODESTAR_EXTRA_ARGS="--network mainnet $LODESTAR_FIXED_VARS --suggestedFeeRecipient $FEE_RECIPIENT --checkpointSyncUrl https://beaconstate-mainnet.chainsafe.io"
 


### PR DESCRIPTION
This PR updates relays for mainnet and holesky.

Mainnet:
- Add Titan relay and WenMerge relay

Holesky:
- Add all known Holesky relays by default