### PR TITLE
kaustinen6: fix verkle-config repo path

### DIFF
--- a/kaustinen6.vars
+++ b/kaustinen6.vars
@@ -8,7 +8,7 @@ LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb pla
 # https://verkle-gen-devnet-6.ethpandaops.io/
 DEVNET_NAME=kaustinen
 SETUP_CONFIG_URL=https://github.com/ethpandaops/verkle-devnets
-CONFIG_GIT_DIR=network-configs/gen-devnet-6
+CONFIG_GIT_DIR=network-configs/gen-devnet-6/metadata
 SETUP_CONFIG_BRANCH=master
 SETUP_CONFIG_INVENTORY_URL=https://config.verkle-gen-devnet-6.ethpandaops.io/api/v1/nodes/inventory
 


### PR DESCRIPTION
This PR changes the repo path to suffix `/metadata` since apparently this might be a new format on how configs are managed for devnets. See [here](https://github.com/ethpandaops/verkle-devnets/tree/master/network-configs).

cc @g11tech 