### PR TITLE
fix the lodestar pectra3 image to a compatible target

### DIFF
--- a/pectra3.vars
+++ b/pectra3.vars
@@ -17,7 +17,7 @@ NETWORK_ID=7011893082
 GETH_IMAGE=ethpandaops/geth:prague-devnet-3
 NETHERMIND_IMAGE=nethermindeth/nethermind:pectra
 
-LODESTAR_IMAGE=ethpandaops/lodestar:unstable
+LODESTAR_IMAGE=ethpandaops/lodestar:unstable-295690b
 
 # Uncomment the following the comment the one below if you want to sync from genesis probably because your EL
 # doesn't support backfill sync ( for e.g. ethereumjs stateless sync etc)


### PR DESCRIPTION
unstable now has devnet4 changes, so fixing the lodestar image to a compatible version