### PR TITLE
Add enodes.txt as potential el bootnode file

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -57,6 +57,7 @@ then
     # one of the files will have el bootnodes
     cp $dataDir/$configGitDir/bootnodes.txt $dataDir/$configGitDir/el_bootnode.txt
     cp $dataDir/$configGitDir/bootnode.txt $dataDir/$configGitDir/el_bootnode.txt
+    cp $dataDir/$configGitDir/enodes.txt $dataDir/$configGitDir/el_bootnode.txt
   fi;
   # if there is a dynamic inventory url pull from there
   if [ -n "$SETUP_CONFIG_INVENTORY_URL" ]


### PR DESCRIPTION
Looks like `bootnode.txt` and `bootnodes.txt` no longer exist in pectra devnets but uses `enodes.txt` instead. 

See https://github.com/ethpandaops/pectra-devnets/tree/master/network-configs/devnet-4/metadata