### PR TITLE
Add mekong configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Look for the .vars file in the folder to see what networks are supported. There 
 3. Sepolia Network: `--network sepolia` (reads `sepolia.vars`)
 4. Verkle Kautinen 7: `--network kaustinen7` (reads `kaustinen7.vars`)
 5. Pectra devnet 4: `--network pectra4` (reads `pectra4.vars`)
+6. Mekong Network: `--network mekong` (reads `mekong.vars`)
 
 Goerli network has been removed as it has been deprecated/sunsetted.
 

--- a/mekong.vars
+++ b/mekong.vars
@@ -1,0 +1,44 @@
+LODESTAR_VALIDATOR_KEYSTORE_ARGS="--importKeystores /keystoresDir/keystores/ --importKeystoresPassword /keystoresDir/pass.txt"
+
+LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
+
+#---------------- Only Modify below if you know what you are doing ----------------
+#----------------------------------------------------------------------------------
+
+DEVNET_NAME=mekong
+# Empty config git dir will be assumed to be clients having bakedin configs
+CONFIG_GIT_DIR=
+NETWORK_ID=7078815900
+
+RELAY_A=""
+
+RELAYS="$RELAY_A"
+
+BESU_IMAGE=ethpandaops/besu:main
+ETHEREUMJS_IMAGE=ethpandaops/ethereumjs:master
+ERIGON_IMAGE=ethpandaops/erigon:main
+GETH_IMAGE=ethpandaops/geth:ethpandaops/geth:master
+NETHERMIND_IMAGE=ethpandaops/nethermind:master
+RETH_IMAGE=ethpandaops/reth:main
+
+LODESTAR_IMAGE=chainsafe/lodestar:next
+
+LODESTAR_EXTRA_ARGS="--network mekong $LODESTAR_FIXED_VARS --checkpointSyncUrl https://checkpoint-sync.mekong.ethpandaops.io"
+
+LODESTAR_VALIDATOR_ARGS="--network mekong $LODESTAR_VAL_FIXED_VARS --suggestedFeeRecipient $FEE_RECIPIENT"
+
+NETHERMIND_EXTRA_ARGS="--config mekong $NETHERMIND_FIXED_VARS"
+
+GETH_EXTRA_ARGS="--mekong --networkid $NETWORK_ID $GETH_FIXED_VARS"
+
+RETH_EXTRA_ARGS="--chain mekong $RETH_FIXED_VARS"
+
+ETHEREUMJS_EXTRA_ARGS="--network mekong $ETHEREUMJS_FIXED_VARS"
+
+BESU_EXTRA_ARGS="--network=mekong --network-id=$NETWORK_ID $BESU_FIXED_VARS"
+
+ERIGON_EXTRA_ARGS="erigon --chain=mekong --networkid=$NETWORK_ID $ERIGON_FIXED_VARS"
+
+EXTRA_BOOTNODES=""
+
+MEVBOOST_VARS="-mekong -relays $RELAYS -min-bid $MIN_BUILDERBID $MEVBOOST_FIXED_VARS"


### PR DESCRIPTION
This PR adds configs for easily booting up the new mekong testnet for public testing of Pectra hard fork.