### PR TITLE
Add nft-devnet-0 config

### DIFF
--- a/nft-devnet-0.vars
+++ b/nft-devnet-0.vars
@@ -11,7 +11,7 @@ SETUP_CONFIG_URL=https://github.com/ethpandaops/nft-devnets
 # Empty config git dir will be assumed to be clients having bakedin configs
 CONFIG_GIT_DIR=network-configs/devnet-0/metadata
 SETUP_CONFIG_BRANCH=master
-SETUP_CONFIG_INVENTORY_URL=https://config.pectra-devnet-4.ethpandaops.io/api/v1/nodes/inventory
+SETUP_CONFIG_INVENTORY_URL=https://config.nft-devnet-0.ethpandaops.io/api/v1/nodes/inventory
 
 NETWORK_ID=7010705318
 
@@ -28,23 +28,21 @@ RETH_IMAGE=ethpandaops/reth:main
 
 LODESTAR_IMAGE=chainsafe/lodestar:next
 
-LODESTAR_EXTRA_ARGS="--checkpointSyncUrl https://checkpoint-sync.nft-devnet-0.ethpandaops.io --bootnodes=enr:-Iq4QN9bKUENAiNQzxU5MhXEjmARDd8AMzKCQ5BI-JTw2Z_PYe7-TXcUhsOmQT7lnJegMZ_UhBQqFrMFLLIZd4BndbWGAZNULoO8gmlkgnY0gmlwhMBR0DeJc2VjcDI1NmsxoQJJ3h8aUO3GJHv-bdvHtsQZ2OEisutelYfGjXO4lSg8BYN1ZHCCIzI
-,enr:-LK4QP79yUM_zGkTHxMy4iKf_qcYoYQMBdG449XcW39hOzaAarNCLpKLYI_a619HFH5Rczk-pq4UxllTIVPeOUYHoRMQh2F0dG5ldHOIAAwAAAAAAACEZXRoMpBu_IrNYBBVED9CDwAAAAAAgmlkgnY0gmlwhMBR0DeJc2VjcDI1NmsxoQN-uOmCDNhWsEyROND46ktbg75nQxZUZducCThKyPxe7oN0Y3CCIyiDdWRwgiMo
- --rest.namespace="*" --network.connectToDiscv5Bootnodes $LODESTAR_FIXED_VARS"
+LODESTAR_EXTRA_ARGS=" --checkpointSyncUrl https://checkpoint-sync.nft-devnet-0.ethpandaops.io --network.connectToDiscv5Bootnodes $LODESTAR_FIXED_VARS"
 
 LODESTAR_VALIDATOR_ARGS=" --suggestedFeeRecipient $FEE_RECIPIENT $LODESTAR_VAL_FIXED_VARS "
 
-NETHERMIND_EXTRA_ARGS="--config mekong $NETHERMIND_FIXED_VARS"
+NETHERMIND_EXTRA_ARGS=" --Init.ChainSpecPath=/network-config/chainspec.json --Init.IsMining=false --Pruning.Mode=None --config=none --Merge.TerminalTotalDifficulty=0 $NETHERMIND_FIXED_VARS"
 
-GETH_EXTRA_ARGS="--mekong --networkid $NETWORK_ID $GETH_FIXED_VARS"
+GETH_EXTRA_ARGS=" --networkid $NETWORK_ID $GETH_FIXED_VARS --syncmode full"
 
-RETH_EXTRA_ARGS="--chain mekong $RETH_FIXED_VARS"
+RETH_EXTRA_ARGS=" $RETH_FIXED_VARS"
 
-ETHEREUMJS_EXTRA_ARGS="--network mekong $ETHEREUMJS_FIXED_VARS"
+ETHEREUMJS_EXTRA_ARGS=" $ETHEREUMJS_FIXED_VARS"
 
 BESU_EXTRA_ARGS="--network=mekong --network-id=$NETWORK_ID $BESU_FIXED_VARS"
 
-ERIGON_EXTRA_ARGS="erigon --chain=mekong --networkid=$NETWORK_ID $ERIGON_FIXED_VARS"
+ERIGON_EXTRA_ARGS="erigon --networkid=$NETWORK_ID $ERIGON_FIXED_VARS"
 
 EXTRA_BOOTNODES=""
 

--- a/nft-devnet-0.vars
+++ b/nft-devnet-0.vars
@@ -28,7 +28,7 @@ RETH_IMAGE=ethpandaops/reth:main
 
 LODESTAR_IMAGE=chainsafe/lodestar:next
 
-LODESTAR_EXTRA_ARGS=" --checkpointSyncUrl https://checkpoint-sync.nft-devnet-0.ethpandaops.io --network.connectToDiscv5Bootnodes $LODESTAR_FIXED_VARS"
+LODESTAR_EXTRA_ARGS=" --checkpointSyncUrl https://checkpoint-sync.nft-devnet-0.ethpandaops.io --network.connectToDiscv5Bootnodes --metrics $LODESTAR_FIXED_VARS"
 
 LODESTAR_VALIDATOR_ARGS=" --suggestedFeeRecipient $FEE_RECIPIENT $LODESTAR_VAL_FIXED_VARS "
 

--- a/nft-devnet-0.vars
+++ b/nft-devnet-0.vars
@@ -1,0 +1,51 @@
+LODESTAR_VALIDATOR_KEYSTORE_ARGS="--importKeystores /keystoresDir/keystores/ --importKeystoresPassword /keystoresDir/pass.txt"
+
+LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
+
+#---------------- Only Modify below if you know what you are doing ----------------
+#----------------------------------------------------------------------------------
+
+# https://nft-devnet-0.ethpandaops.io/
+DEVNET_NAME=nft-devnet-0
+SETUP_CONFIG_URL=https://github.com/ethpandaops/nft-devnets
+# Empty config git dir will be assumed to be clients having bakedin configs
+CONFIG_GIT_DIR=network-configs/devnet-0/metadata
+SETUP_CONFIG_BRANCH=master
+SETUP_CONFIG_INVENTORY_URL=https://config.pectra-devnet-4.ethpandaops.io/api/v1/nodes/inventory
+
+NETWORK_ID=7010705318
+
+RELAY_A=""
+
+RELAYS="$RELAY_A"
+
+BESU_IMAGE=ethpandaops/besu:main
+ETHEREUMJS_IMAGE=ethpandaops/ethereumjs:master
+ERIGON_IMAGE=ethpandaops/erigon:main
+GETH_IMAGE=ethpandaops/geth:master
+NETHERMIND_IMAGE=ethpandaops/nethermind:master
+RETH_IMAGE=ethpandaops/reth:main
+
+LODESTAR_IMAGE=chainsafe/lodestar:next
+
+LODESTAR_EXTRA_ARGS="--checkpointSyncUrl https://checkpoint-sync.nft-devnet-0.ethpandaops.io --bootnodes=enr:-Iq4QN9bKUENAiNQzxU5MhXEjmARDd8AMzKCQ5BI-JTw2Z_PYe7-TXcUhsOmQT7lnJegMZ_UhBQqFrMFLLIZd4BndbWGAZNULoO8gmlkgnY0gmlwhMBR0DeJc2VjcDI1NmsxoQJJ3h8aUO3GJHv-bdvHtsQZ2OEisutelYfGjXO4lSg8BYN1ZHCCIzI
+,enr:-LK4QP79yUM_zGkTHxMy4iKf_qcYoYQMBdG449XcW39hOzaAarNCLpKLYI_a619HFH5Rczk-pq4UxllTIVPeOUYHoRMQh2F0dG5ldHOIAAwAAAAAAACEZXRoMpBu_IrNYBBVED9CDwAAAAAAgmlkgnY0gmlwhMBR0DeJc2VjcDI1NmsxoQN-uOmCDNhWsEyROND46ktbg75nQxZUZducCThKyPxe7oN0Y3CCIyiDdWRwgiMo
+ --rest.namespace="*" --network.connectToDiscv5Bootnodes $LODESTAR_FIXED_VARS"
+
+LODESTAR_VALIDATOR_ARGS=" --suggestedFeeRecipient $FEE_RECIPIENT $LODESTAR_VAL_FIXED_VARS "
+
+NETHERMIND_EXTRA_ARGS="--config mekong $NETHERMIND_FIXED_VARS"
+
+GETH_EXTRA_ARGS="--mekong --networkid $NETWORK_ID $GETH_FIXED_VARS"
+
+RETH_EXTRA_ARGS="--chain mekong $RETH_FIXED_VARS"
+
+ETHEREUMJS_EXTRA_ARGS="--network mekong $ETHEREUMJS_FIXED_VARS"
+
+BESU_EXTRA_ARGS="--network=mekong --network-id=$NETWORK_ID $BESU_FIXED_VARS"
+
+ERIGON_EXTRA_ARGS="erigon --chain=mekong --networkid=$NETWORK_ID $ERIGON_FIXED_VARS"
+
+EXTRA_BOOTNODES=""
+
+MEVBOOST_VARS="-mekong -relays $RELAYS -min-bid $MIN_BUILDERBID $MEVBOOST_FIXED_VARS"


### PR DESCRIPTION
This config allows you to run Lodestar with current nft-devnet-0 configs. Remember to adjust `--max-old-space-size=16384` in the setup.sh script to ensure you don't crash from heap memory limits:

https://github.com/ChainSafe/lodestar-quickstart/blob/7728e5fc9fda27e8819af043059cdc43b23fb170/setup.sh#L342

Enable with the setup.sh script and these parameters:
`./setup.sh --dataDir nft-devnet-0-data --elClient geth --network nft-devnet-0 --dockerWithSudo --detached`