### PR TITLE
Mekong testnet updates

### DIFF
--- a/mekong.vars
+++ b/mekong.vars
@@ -11,7 +11,7 @@ SETUP_CONFIG_URL=https://github.com/ethpandaops/mekong-devnets
 # Empty config git dir will be assumed to be clients having bakedin configs
 CONFIG_GIT_DIR=network-configs/devnet-0/metadata
 SETUP_CONFIG_BRANCH=master
-SETUP_CONFIG_INVENTORY_URL=https://config.nft-devnet-0.ethpandaops.io/api/v1/nodes/inventory
+# SETUP_CONFIG_INVENTORY_URL=https://config.devnet-0.ethpandaops.io/api/v1/nodes/inventory
 
 NETWORK_ID=7078815900
 

--- a/mekong.vars
+++ b/mekong.vars
@@ -5,9 +5,14 @@ LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb pla
 #---------------- Only Modify below if you know what you are doing ----------------
 #----------------------------------------------------------------------------------
 
+# https://mekong.ethpandaops.io/
 DEVNET_NAME=mekong
+SETUP_CONFIG_URL=https://github.com/ethpandaops/mekong-devnets
 # Empty config git dir will be assumed to be clients having bakedin configs
-CONFIG_GIT_DIR=
+CONFIG_GIT_DIR=network-configs/devnet-0/metadata
+SETUP_CONFIG_BRANCH=master
+SETUP_CONFIG_INVENTORY_URL=https://config.nft-devnet-0.ethpandaops.io/api/v1/nodes/inventory
+
 NETWORK_ID=7078815900
 
 RELAY_A=""
@@ -29,7 +34,7 @@ LODESTAR_VALIDATOR_ARGS="--network mekong $LODESTAR_VAL_FIXED_VARS --suggestedFe
 
 NETHERMIND_EXTRA_ARGS="--config mekong $NETHERMIND_FIXED_VARS"
 
-GETH_EXTRA_ARGS="--mekong --networkid $NETWORK_ID $GETH_FIXED_VARS"
+GETH_EXTRA_ARGS="--networkid $NETWORK_ID $GETH_FIXED_VARS"
 
 RETH_EXTRA_ARGS="--chain mekong $RETH_FIXED_VARS"
 


### PR DESCRIPTION
This PR pulls metadata from the ethpandaops repo for configuring Lodestar + EL. Also fixes the preset config for Geth which doesn't exist, so it just uses the network ID to identify Mekong. 

Currently only works with Geth + Nethermind.

For Geth:
`./setup.sh --dataDir mekong --elClient geth --network mekong --dockerWithSudo --detached` 

For Nethermind:
`./setup.sh --dataDir mekong --elClient nethermind --network mekong --dockerWithSudo --detached` 

If the ethpandaops checkpoint sync state is too old, add `--ignoreWeakSubjectivityCheck` to mekong.vars under `LODESTAR_EXTRA_ARGS` 