### PR TITLE
Update geth image to use stable tag

### DIFF
--- a/import-images.sh
+++ b/import-images.sh
@@ -2,7 +2,7 @@
 
 if [ ! -n "$GETH_IMAGE" ]
 then
-  GETH_IMAGE=ethereum/client-go:latest
+  GETH_IMAGE=ethereum/client-go:stable
 fi;
 
 if [ ! -n "$RETH_IMAGE" ]


### PR DESCRIPTION
Currently, Geth uses their `latest` tag to pull their latest unstable image. This is incorrect and we should by default be pulling their `stable` image as we do for other ELs with this script.

v1.15.x is the current `latest` on the Geth tag. The database changes there are incompatible and you cannot downgrade bag to v1.14.x after upgrading. 

This PR will always pull latest stable image. 