### PR TITLE
Add pectra7

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Look for the .vars file in the folder to see what networks are supported. There 
 2. Holesky Network: `--network holesky` (reads `holesky.vars`)
 3. Sepolia Network: `--network sepolia` (reads `sepolia.vars`)
 4. Verkle Kautinen 7: `--network kaustinen7` (reads `kaustinen7.vars`)
-5. Pectra devnet 4: `--network pectra4` (reads `pectra4.vars`)
+5. Pectra devnet 7: `--network pectra7` (reads `pectra7.vars`)
 6. Mekong Network: `--network mekong` (reads `mekong.vars`)
 
 Goerli network has been removed as it has been deprecated/sunsetted.

--- a/pectra7.vars
+++ b/pectra7.vars
@@ -5,24 +5,19 @@ LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb pla
 #---------------- Only Modify below if you know what you are doing ----------------
 #----------------------------------------------------------------------------------
 
-# https://pectra-devnet-4.ethpandaops.io/
-DEVNET_NAME=pectra4
+# https://pectra-devnet-7.ethpandaops.io/
+DEVNET_NAME=pectra7
 SETUP_CONFIG_URL=https://github.com/ethpandaops/pectra-devnets
-CONFIG_GIT_DIR=network-configs/devnet-4/metadata
+CONFIG_GIT_DIR=network-configs/devnet-7/metadata
 SETUP_CONFIG_BRANCH=master
-SETUP_CONFIG_INVENTORY_URL=https://config.pectra-devnet-4.ethpandaops.io/api/v1/nodes/inventory
+SETUP_CONFIG_INVENTORY_URL=https://config.pectra-devnet-7.ethpandaops.io/api/v1/nodes/inventory
 
-NETWORK_ID=7042905162
-
-GETH_IMAGE=ethpandaops/geth:lightclient-prague-devnet-4-37035c5
-NETHERMIND_IMAGE=ethpandaops/nethermind:pectra_devnet_4-c3827bc
-
-LODESTAR_IMAGE=ethpandaops/lodestar:devnet-4-1531b19
+NETWORK_ID=7032118028
 
 # Uncomment the following the comment the one below if you want to sync from genesis probably because your EL
 # doesn't support backfill sync ( for e.g. ethereumjs stateless sync etc)
 #
-LODESTAR_EXTRA_ARGS="$LODESTAR_FIXED_VARS --checkpointSyncUrl https://checkpoint-sync.pectra-devnet-4.ethpandaops.io --ignoreWeakSubjectivityCheck"
+LODESTAR_EXTRA_ARGS="$LODESTAR_FIXED_VARS --checkpointSyncUrl https://checkpoint-sync.pectra-devnet-7.ethpandaops.io --ignoreWeakSubjectivityCheck"
 # LODESTAR_EXTRA_ARGS="$LODESTAR_FIXED_VARS --checkpointSyncUrl https://eth:g11techisntoneperson@bn.lodestar-geth-9.verkle-gen-devnet-6.ethpandaops.io"
 
 LODESTAR_VALIDATOR_ARGS="$LODESTAR_VAL_FIXED_VARS --suggestedFeeRecipient $FEE_RECIPIENT"


### PR DESCRIPTION
Remove support for Pectra4 and add Pectra7.

We should be able to use master release of each client as Pectra-related features should already be in their main release.